### PR TITLE
Refactor GitHub Actions workflow to use npm directly

### DIFF
--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -24,28 +24,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Detect package manager
-        id: detect-package-manager
-        run: |
-          if [ -f "${{ github.workspace }}/movies-app/yarn.lock" ]; then
-            echo "manager=yarn" >> $GITHUB_OUTPUT
-            echo "command=install" >> $GITHUB_OUTPUT
-            echo "runner=yarn" >> $GITHUB_OUTPUT
-            exit 0
-          elif [ -f "${{ github.workspace }}/movies-app/package.json" ]; then
-            echo "manager=npm" >> $GITHUB_OUTPUT
-            echo "command=ci" >> $GITHUB_OUTPUT
-            echo "runner=npx --no-install" >> $GITHUB_OUTPUT
-            exit 0
-          else
-            echo "Unable to determine package manager"
-            exit 1
-          fi
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
           node-version: "20"
-          cache: ${{ steps.detect-package-manager.outputs.manager }}
       - name: Setup Pages
         uses: actions/configure-pages@v5
         with:
@@ -57,9 +39,9 @@ jobs:
           key: ${{ runner.os }}-nextjs-${{ hashFiles('**/movies-app/package-lock.json', '**/movies-app/yarn.lock') }}-${{ hashFiles('**/movies-app/*.[jt]s', '**/movies-app/*.[jt]sx') }}
           restore-keys: ${{ runner.os }}-nextjs-${{ hashFiles('**/movies-app/package-lock.json', '**/movies-app/yarn.lock') }}-
       - name: Install dependencies
-        run: ${{ steps.detect-package-manager.outputs.manager }} ${{ steps.detect-package-manager.outputs.command }} --cwd movies-app
+        run: npm ci --cwd movies-app
       - name: Build with Next.js
-        run: ${{ steps.detect-package-manager.outputs.runner }} next build --cwd movies-app
+        run: npm run next build --cwd movies-app
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:


### PR DESCRIPTION
Remove package manager detection from the workflow and directly utilize npm commands for installing dependencies and building the project.