### PR TITLE
Update GitHub Actions workflow for Next.js build step

### DIFF
--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -42,7 +42,7 @@ jobs:
         run: npm ci
         working-directory: ./movies-app
       - name: Build with Next.js
-        run: npm run next build
+        run: npm run build
         working-directory: ./movies-app
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
Change the build command in the GitHub Actions workflow to use `npm run build` for the Next.js application.