### PR TITLE
Update artifact path in GitHub Actions workflow for deployment

### DIFF
--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v1
         with:
-          path: ./build
+          path: movies-app/build
 
 
   deploy:


### PR DESCRIPTION
Change the artifact path in the GitHub Actions workflow to ensure the correct directory is used for deployment.