### PR TITLE
Update artifact path in GitHub Actions workflow

### DIFF
--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v1
         with:
-          path: movies-app/build
+          path: movies-app/out
 
 
   deploy:


### PR DESCRIPTION
Change the artifact path in the GitHub Actions workflow from './build' to './out' to reflect the new output directory.