### PR TITLE
Set BASEPATH environment variable for movies app configuration

### DIFF
--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -33,6 +33,8 @@ jobs:
           npm ci
           npm run build
         working-directory: movies-app
+        env:
+          BASEPATH: /playwright-movies-app
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v1
         with:

--- a/movies-app/next.config.ts
+++ b/movies-app/next.config.ts
@@ -1,7 +1,7 @@
 import { NextConfig } from 'next'
 
 const config: NextConfig = {  
-  basePath: '/playwright-movies-app',
+  basePath: process.env.BASEPATH,
   webpack: (config) => {
     config.module.rules.push({
       test: /\.svg$/,


### PR DESCRIPTION
Configure the movies app to use the BASEPATH environment variable for its base path, enhancing flexibility in deployment settings.