### PR TITLE
Refactor image path constants to use addBasePath for improved handling

### DIFF
--- a/movies-app/utils/constants/image-paths.js
+++ b/movies-app/utils/constants/image-paths.js
@@ -1,10 +1,12 @@
+import { addBasePath } from 'next/dist/client/add-base-path';
 
-const NOTHING_PLACEHOLDER_IMAGE_PATH = '/assets/svgs/nothing.svg';
-const PROFILE_PLACEHOLDER_IMAGE_PATH = '/assets/svgs/person.svg';
-const ERROR_IMAGE_PATH = '/assets/svgs/error.svg';
-const LOGO_IMAGE_PATH = '/assets/svgs/logo.svg';
-const DARK_TMDB_IMAGE_PATH = '/assets/svgs/tmdbgreen.svg';
-const LIGHT_TMDB_IMAGE_PATH = '/assets/svgs/tmdb.svg';
+const NOTHING_PLACEHOLDER_IMAGE_PATH = addBasePath('/assets/svgs/nothing.svg');
+const PROFILE_PLACEHOLDER_IMAGE_PATH = addBasePath('/assets/svgs/person.svg');
+const ERROR_IMAGE_PATH = addBasePath('/assets/svgs/error.svg');
+const LOGO_IMAGE_PATH = addBasePath('/assets/svgs/logo.svg');
+const DARK_TMDB_IMAGE_PATH = addBasePath('/assets/svgs/tmdbgreen.svg');
+const LIGHT_TMDB_IMAGE_PATH = addBasePath('/assets/svgs/tmdb.svg');
+
 
 export {
   NOTHING_PLACEHOLDER_IMAGE_PATH,


### PR DESCRIPTION
Update image path constants to utilize `addBasePath`, enhancing path management across the application.