### PR TITLE
fix: allow PRs from forks to run tests

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -19,11 +19,10 @@ jobs:
       run: cd movies-app && npm ci
     - name: Install Playwright Browsers
       run: npx playwright install --with-deps
+    - name: Setup .env file with mock credentials
+      run: cp .env.example .env
     - name: Run Playwright tests
       run: npm run test
-      env:
-        MOVIES_USERNAME: ${{ secrets.MOVIES_USERNAME }}
-        MOVIES_PASSWORD: ${{ secrets.MOVIES_PASSWORD }}
     - uses: actions/upload-artifact@v4
       if: ${{ !cancelled() }}
       with:


### PR DESCRIPTION
PRs from forks don't have access to secrets, so they can't run tests currently. The secrets don't contain any actual credentials, just mock data. So it's fine to remove that, and use the `.env.example` file instead.