### PR TITLE
Update Playwright to version 1.52.0-alpha-2025-03-03 and enable Git info capture

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.18.0",
-        "@playwright/test": "^1.51.0-alpha-2025-01-29",
+        "@playwright/test": "^1.52.0-alpha-2025-03-03",
         "@types/eslint__js": "^8.42.3",
         "@types/node": "^22.5.4",
         "eslint": "^9.18.0",
@@ -279,13 +279,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.51.0-alpha-2025-01-29",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.51.0-alpha-2025-01-29.tgz",
-      "integrity": "sha512-Usy4iIEx2vEDbMyIaCoJyQCb+8C6dLlvXja2W465zQEWWzzs7cjTO0QuzTdTBYiyiwHj46HV0if4CdfaA1DlYw==",
+      "version": "1.52.0-alpha-2025-03-03",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.52.0-alpha-2025-03-03.tgz",
+      "integrity": "sha512-gpnrZlMsaKToS4i8Rkf6gK4fBAjKFruAYE6TpPNR2NyrEloekw1d94+cMq45xWlXwFcu+1vJ1Ne+yy0bVwc2gw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.51.0-alpha-2025-01-29"
+        "playwright": "1.52.0-alpha-2025-03-03"
       },
       "bin": {
         "playwright": "cli.js"
@@ -1568,13 +1568,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.51.0-alpha-2025-01-29",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.51.0-alpha-2025-01-29.tgz",
-      "integrity": "sha512-9xD/7wh+kvy1464iNBM7O+xvbCioDemBQ3KoeEr7pCl0iFGl6iPQL79Ptl2kZp35Jm2xBqlkSFrBxOJ5evoTFA==",
+      "version": "1.52.0-alpha-2025-03-03",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.52.0-alpha-2025-03-03.tgz",
+      "integrity": "sha512-SmXPfCPVfU0oQsgep5orz35uWcdYrxTWngX44x4Op5uxQHviwXvaEXsKHVOckmbZr6TaDTjHCpx6fO1xS1uQyQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.51.0-alpha-2025-01-29"
+        "playwright-core": "1.52.0-alpha-2025-03-03"
       },
       "bin": {
         "playwright": "cli.js"
@@ -1587,9 +1587,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.51.0-alpha-2025-01-29",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.51.0-alpha-2025-01-29.tgz",
-      "integrity": "sha512-WKzCXjc3ln40ryqONHcCuI4Y+WjkaJOI4JsVgkaV8XRuVLH7Oj77dHO3x8YsbezLijYelHQX7yuKjWbvq/bqXA==",
+      "version": "1.52.0-alpha-2025-03-03",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.52.0-alpha-2025-03-03.tgz",
+      "integrity": "sha512-I1GXSkyY3ofHC0iUzPujI83OrnNNjt9Jc1COqlDmZ+WKRdpJ6uLXXDnL19nux3KTkUse1QflQV9EzOi1F79pJg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.18.0",
-    "@playwright/test": "^1.51.0-alpha-2025-01-29",
+    "@playwright/test": "^1.52.0-alpha-2025-03-03",
     "@types/eslint__js": "^8.42.3",
     "@types/node": "^22.5.4",
     "eslint": "^9.18.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -33,6 +33,7 @@ export default defineConfig({
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',
   },
+  captureGitInfo: { commit: true, diff: true },
 
   /* Configure projects for major browsers */
   projects: [


### PR DESCRIPTION
Upgrade Playwright dependencies to the latest alpha version and configure the project to capture Git information during testing.