### PR TITLE
Fix: Logo showing as 404 error

### DIFF
--- a/movies-app/components/Logo/index.js
+++ b/movies-app/components/Logo/index.js
@@ -24,7 +24,7 @@ const Logo = () => (
           className='logo-img'
           width='150'
           height='150'
-          src=''
+          src={LOGO_IMAGE_PATH}
           alt='movie ticket' />
       </picture>
 


### PR DESCRIPTION
## Problem
The main logo in the header was displaying as a broken image (404 error) because the `<img>` tag had an empty `src` attribute.

## Solution
Added `src={LOGO_IMAGE_PATH}` to the img element in the Logo component to properly reference the logo.svg file located at `/assets/svgs/logo.svg`.

## Changes
- Updated `movies-app/components/Logo/index.js` to include the src attribute pointing to LOGO_IMAGE_PATH

## Testing
- ✅ Logo now displays correctly in the header
- ✅ No 404 errors in browser console
- ✅ Logo loads properly on all screen sizes

## Screenshots
Before: Logo showed as broken image
After: Logo displays correctly as a movie ticket icon