### PR TITLE
Fix movie details client error from missing spoken_languages

### DIFF
--- a/mock-api/src/enriched-movies.json
+++ b/mock-api/src/enriched-movies.json
@@ -168,6 +168,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -349,6 +353,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -520,6 +528,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -691,6 +703,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -863,6 +879,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -1035,6 +1055,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -1201,6 +1225,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -1372,6 +1400,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -1538,6 +1570,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -1704,6 +1740,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -1879,6 +1919,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -2054,6 +2098,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -2225,6 +2273,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -2392,6 +2444,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -2558,6 +2614,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -2729,6 +2789,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -2905,6 +2969,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -3076,6 +3144,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -3247,6 +3319,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -3422,6 +3498,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -3588,6 +3668,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -3760,6 +3844,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -3931,6 +4019,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -4102,6 +4194,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -4274,6 +4370,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -4445,6 +4545,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -4616,6 +4720,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -4782,6 +4890,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -4943,6 +5055,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -5085,6 +5201,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -5252,6 +5372,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -5423,6 +5547,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -5603,6 +5731,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -5774,6 +5906,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -5945,6 +6081,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -6121,6 +6261,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -6297,6 +6441,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -6468,6 +6616,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -6639,6 +6791,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -6805,6 +6961,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -6976,6 +7136,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -7147,6 +7311,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -7324,6 +7492,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -7495,6 +7667,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -7666,6 +7842,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -7843,6 +8023,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -8014,6 +8198,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -8190,6 +8378,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -8370,6 +8562,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -8537,6 +8733,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -8709,6 +8909,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -8880,6 +9084,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -9051,6 +9259,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -9217,6 +9429,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -9383,6 +9599,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -9549,6 +9769,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -9723,6 +9947,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -9889,6 +10117,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -10058,6 +10290,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -10229,6 +10465,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -10405,6 +10645,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -10583,6 +10827,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -10755,6 +11003,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -10901,6 +11153,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -11045,6 +11301,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -11226,6 +11486,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -11397,6 +11661,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -11568,6 +11836,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -11735,6 +12007,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -11907,6 +12183,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -12074,6 +12354,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -12247,6 +12531,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -12416,6 +12704,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -12560,6 +12852,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -12726,6 +13022,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -12892,6 +13192,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -13062,6 +13366,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -13223,6 +13531,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -13400,6 +13712,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -13571,6 +13887,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -13738,6 +14058,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -13872,6 +14196,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -14048,6 +14376,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -14220,6 +14552,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -14386,6 +14722,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -14557,6 +14897,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -14723,6 +15067,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -14890,6 +15238,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -15066,6 +15418,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -15237,6 +15593,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -15421,6 +15781,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -15601,6 +15965,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -15772,6 +16140,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -15938,6 +16310,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -16109,6 +16485,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -16280,6 +16660,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -16451,6 +16835,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -16569,6 +16957,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -16739,6 +17131,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -16857,6 +17253,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -16926,6 +17326,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -17092,6 +17496,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -17199,6 +17607,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -17370,6 +17782,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -17541,6 +17957,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -17712,6 +18132,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -17883,6 +18307,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -18054,6 +18482,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -18225,6 +18657,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -18396,6 +18832,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -18567,6 +19007,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -18738,6 +19182,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -18909,6 +19357,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -19080,6 +19532,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -19251,6 +19707,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -19422,6 +19882,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -19593,6 +20057,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -19764,6 +20232,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -19935,6 +20407,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -20106,6 +20582,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -20277,6 +20757,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -20448,6 +20932,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -20619,6 +21107,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -20795,6 +21287,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -20966,6 +21462,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -21137,6 +21637,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -21308,6 +21812,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -21479,6 +21987,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -21650,6 +22162,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -21821,6 +22337,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -21992,6 +22512,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -22158,6 +22682,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -22329,6 +22857,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -22500,6 +23032,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   },
   {
@@ -22671,6 +23207,10 @@
         }
       ],
       "crew": []
+    },
+    "spoken_languages": [],
+    "videos": {
+      "results": []
     }
   }
 ]

--- a/movies-app/components/MovieSummary/MovieInfo/BasicsSection/LanguagesRuntimeRelease/index.js
+++ b/movies-app/components/MovieSummary/MovieInfo/BasicsSection/LanguagesRuntimeRelease/index.js
@@ -10,9 +10,9 @@ const getYear = date => {
   return year;
 };
 
-const renderInfo = (spokenLanguages, runtime, releaseDate) => {
+const renderInfo = (spokenLanguages = [], runtime, releaseDate) => {
   const pieces = [];
-  const ariaLabel = []; ;
+  const ariaLabel = [];
   if (spokenLanguages.length !== 0) {
     pieces.push(spokenLanguages[0].name);
     ariaLabel.push('language');

--- a/movies-app/components/MovieSummary/MovieInfo/TheGenresSection/index.js
+++ b/movies-app/components/MovieSummary/MovieInfo/TheGenresSection/index.js
@@ -10,7 +10,7 @@ const TheGenresSection = ({
     <div className={className} >
       <SummarySectionHeading id="genres">The Genres</SummarySectionHeading>
       <ul className='the-genres' aria-label="genres">
-        {genres.map(genre => (
+        {(genres || []).map(genre => (
             <GenreLink
               key={genre.id}
               genre={genre}


### PR DESCRIPTION
## Summary
- Trimming cast fixtures had dropped `spoken_languages`, which crashed movie details (`spokenLanguages.length`)
- Restore empty `spoken_languages` / `videos` defaults in mock fixtures
- Harden genres/spoken_languages rendering against missing arrays
- Production Worker already redeployed with the fixture fix

## Test plan
- [ ] Open a movie details page on GitHub Pages — no client error
- [ ] Cast section still shows
- [ ] Hard refresh still works


Made with [Cursor](https://cursor.com)