### PR TITLE
Fix deployed login failing due to blocked third-party cookies

### DIFF
--- a/mock-api/README.md
+++ b/mock-api/README.md
@@ -54,7 +54,9 @@ Then:
 1. Keep [`.github/workflows/nextjs.yml`](../.github/workflows/nextjs.yml) pointed at the Workers URL (or set repo variable `NEXT_PUBLIC_TMDB_API_BASE_URL`).
 2. For CI deploys, add repo secrets `CLOUDFLARE_API_TOKEN` (Workers Edit) and optionally `CLOUDFLARE_ACCOUNT_ID`, then use the **Deploy mock API** GitHub Action.
 
-Production sets `COOKIE_SECURE=true` / `NODE_ENV=production` in `wrangler.jsonc`, which enables `Secure; SameSite=None` cookies for cross-site use from GitHub Pages.
+Production sets `COOKIE_SECURE=true` / `NODE_ENV=production` in `wrangler.jsonc`, which enables `Secure; SameSite=None` cookies for local/same-site use.
+
+Cross-site login from GitHub Pages does **not** rely on third-party cookies (many browsers block them). After `/auth/access`, the mock redirects back with `access_token` and `account_id` query params; the Movies app reads those and stores them in `localStorage`. An in-memory approval map also backs `/4/auth/access_token` for clients that still use the exchange endpoint.
 
 ### Notes
 

--- a/mock-api/README.md
+++ b/mock-api/README.md
@@ -56,7 +56,7 @@ Then:
 
 Production sets `COOKIE_SECURE=true` / `NODE_ENV=production` in `wrangler.jsonc`, which enables `Secure; SameSite=None` cookies for local/same-site use.
 
-Cross-site login from GitHub Pages does **not** rely on third-party cookies (many browsers block them). After `/auth/access`, the mock redirects back with `access_token` and `account_id` query params; the Movies app reads those and stores them in `localStorage`. An in-memory approval map also backs `/4/auth/access_token` for clients that still use the exchange endpoint.
+Cross-site login from GitHub Pages does **not** rely on third-party cookies (many browsers block them). After `/auth/access`, the mock redirects back with `access_token` and `account_id` in the URL hash; the Movies app reads those and stores them in `localStorage`. An in-memory approval map also backs `/4/auth/access_token` for clients that still use the exchange endpoint.
 
 ### Notes
 

--- a/mock-api/src/app.ts
+++ b/mock-api/src/app.ts
@@ -41,6 +41,11 @@ type List = {
 const listStore = new Map<string, List>()
 const accountListIds = new Map<string, Set<string>>()
 
+// Approved request_tokens from /auth/access. Used so /4/auth/access_token does not
+// depend on third-party cookies (blocked by many browsers for GitHub Pages → Workers).
+type ApprovedAuth = { access_token: string; account_id: string }
+const approvedTokens = new Map<string, ApprovedAuth>()
+
 const dedupedMovies = enrichedMovies.filter((movie, index) => enrichedMovies.findIndex(m => m.id === movie.id) === index)
 
 // Lazy-init Orama: insertMultiple uses setTimeout, which Workers disallow at global scope.
@@ -113,6 +118,7 @@ app.post('/test/reset', (c) => {
   }
   listStore.clear()
   accountListIds.clear()
+  approvedTokens.clear()
   return c.json({ success: true })
 })
 
@@ -211,20 +217,39 @@ app.get("/auth/access", async (c) => {
 })
 app.post("/auth/access", async (c) => {
   const request_token = c.req.query("request_token")
+  if (!request_token) return c.text("missing request_token", { status: 400 })
   const form = await c.req.formData()
   const email = form.get("email") as string
   const { redirect_to } = JSON.parse(Buffer.from(request_token, "base64").toString())
   const account_id = encodeURIComponent(email);
   const access_token = Buffer.from(JSON.stringify({ account_id })).toString("base64")
+  // Keep cookies for same-site local/Playwright flows.
   setCookie(c, request_token.slice(0, 6), access_token, cookieSettings);
   setCookie(c, "current_account", account_id, cookieSettings);
-  return c.redirect(redirect_to)
+  approvedTokens.set(request_token, { access_token, account_id })
+
+  // Also hand tokens back on the redirect URL so cross-site login works when
+  // browsers block third-party cookies on the later access_token exchange.
+  let redirectUrl: URL
+  try {
+    redirectUrl = new URL(redirect_to)
+  } catch {
+    return c.text("invalid redirect_to", { status: 400 })
+  }
+  redirectUrl.searchParams.set("access_token", access_token)
+  redirectUrl.searchParams.set("account_id", account_id)
+  return c.redirect(redirectUrl.toString())
 })
 app.post("/4/auth/access_token", async (c) => {
   const { request_token } = await c.req.json()
-  const access_token = getCookie(c, request_token.slice(0, 6));
+  const approved = approvedTokens.get(request_token)
+  const access_token = approved?.access_token || getCookie(c, request_token.slice(0, 6));
   if (!access_token) return c.text("unauthenticated", { status: 401 })
-  const { account_id } = JSON.parse(Buffer.from(access_token, "base64").toString())
+  const account_id = approved?.account_id
+    || JSON.parse(Buffer.from(access_token, "base64").toString()).account_id
+
+  // One-time use when present in memory (cookie path may still re-read).
+  approvedTokens.delete(request_token)
 
   return c.json({
     success: true,

--- a/mock-api/src/app.ts
+++ b/mock-api/src/app.ts
@@ -228,16 +228,16 @@ app.post("/auth/access", async (c) => {
   setCookie(c, "current_account", account_id, cookieSettings);
   approvedTokens.set(request_token, { access_token, account_id })
 
-  // Also hand tokens back on the redirect URL so cross-site login works when
-  // browsers block third-party cookies on the later access_token exchange.
+  // Hand tokens back in the URL hash so cross-site login works when browsers
+  // block third-party cookies. Hash avoids Next.js query-string sync issues.
   let redirectUrl: URL
   try {
     redirectUrl = new URL(redirect_to)
   } catch {
     return c.text("invalid redirect_to", { status: 400 })
   }
-  redirectUrl.searchParams.set("access_token", access_token)
-  redirectUrl.searchParams.set("account_id", account_id)
+  const authHash = new URLSearchParams({ access_token, account_id })
+  redirectUrl.hash = authHash.toString()
   return c.redirect(redirectUrl.toString())
 })
 app.post("/4/auth/access_token", async (c) => {

--- a/mock-api/tests/api.spec.ts
+++ b/mock-api/tests/api.spec.ts
@@ -1,5 +1,45 @@
 import { test, expect } from '@playwright/test';
 
+test('login redirects with tokens and access_token works without cookies', async ({
+  request,
+}) => {
+  const redirectTo = 'https://debs-obrien.github.io/playwright-movies-app/';
+  const tokenRes = await request.post('/4/auth/request_token', {
+    data: { redirect_to: redirectTo },
+  });
+  await expect(tokenRes).toBeOK();
+  const { request_token } = await tokenRes.json();
+  expect(request_token).toBeTruthy();
+
+  const loginRes = await request.post(
+    `/auth/access?request_token=${encodeURIComponent(request_token)}`,
+    {
+      form: {
+        email: 'cors-fix@example.com',
+        password: 'password',
+      },
+      maxRedirects: 0,
+    },
+  );
+  expect(loginRes.status()).toBe(302);
+  const location = loginRes.headers()['location'];
+  expect(location).toBeTruthy();
+  const redirected = new URL(location!);
+  const accessToken = redirected.searchParams.get('access_token');
+  const accountId = redirected.searchParams.get('account_id');
+  expect(accessToken).toBeTruthy();
+  expect(accountId).toBe(encodeURIComponent('cors-fix@example.com'));
+
+  // New context has no cookies — exchange must use in-memory approval.
+  const exchange = await request.post('/4/auth/access_token', {
+    data: { request_token },
+  });
+  await expect(exchange).toBeOK();
+  const body = await exchange.json();
+  expect(body.access_token).toBe(accessToken);
+  expect(body.account_id).toBe(accountId);
+});
+
 test('test reset endpoint clears list store', async ({ request }) => {
   const create = await request.post('/4/list', {
     data: { name: 'temp', description: 'reset me', public: false },

--- a/mock-api/tests/api.spec.ts
+++ b/mock-api/tests/api.spec.ts
@@ -25,8 +25,9 @@ test('login redirects with tokens and access_token works without cookies', async
   const location = loginRes.headers()['location'];
   expect(location).toBeTruthy();
   const redirected = new URL(location!);
-  const accessToken = redirected.searchParams.get('access_token');
-  const accountId = redirected.searchParams.get('account_id');
+  const hashParams = new URLSearchParams(redirected.hash.replace(/^#/, ''));
+  const accessToken = hashParams.get('access_token');
+  const accountId = hashParams.get('account_id');
   expect(accessToken).toBeTruthy();
   expect(accountId).toBe(encodeURIComponent('cors-fix@example.com'));
 

--- a/movies-app/utils/hocs/AuthProvider/index.js
+++ b/movies-app/utils/hocs/AuthProvider/index.js
@@ -23,9 +23,12 @@ const AuthProvider = ({ children }) => {
   useEffect(() => {
     (async () => {
       try {
-        // Prefer tokens returned on the login redirect (works cross-site without
-        // third-party cookies). Strip them from the URL so they are not bookmarked.
-        const redirectParams = new URLSearchParams(window.location.search);
+        // Prefer tokens returned on the login redirect hash (works cross-site
+        // without third-party cookies). Strip them so they are not bookmarked.
+        const hash = window.location.hash.startsWith('#')
+          ? window.location.hash.slice(1)
+          : window.location.hash;
+        const redirectParams = new URLSearchParams(hash);
         const redirectAccessToken = redirectParams.get('access_token') || '';
         const redirectAccountId = redirectParams.get('account_id') || '';
         if (redirectAccessToken && redirectAccountId) {
@@ -34,13 +37,7 @@ const AuthProvider = ({ children }) => {
             access_token: redirectAccessToken,
             account_id: redirectAccountId
           });
-          redirectParams.delete('access_token');
-          redirectParams.delete('account_id');
-          const cleanSearch = redirectParams.toString();
-          const cleanUrl =
-            window.location.pathname +
-            (cleanSearch ? `?${cleanSearch}` : '') +
-            window.location.hash;
+          const cleanUrl = window.location.pathname + window.location.search;
           window.history.replaceState({}, document.title, cleanUrl);
 
           setState({

--- a/movies-app/utils/hocs/AuthProvider/index.js
+++ b/movies-app/utils/hocs/AuthProvider/index.js
@@ -23,6 +23,35 @@ const AuthProvider = ({ children }) => {
   useEffect(() => {
     (async () => {
       try {
+        // Prefer tokens returned on the login redirect (works cross-site without
+        // third-party cookies). Strip them from the URL so they are not bookmarked.
+        const redirectParams = new URLSearchParams(window.location.search);
+        const redirectAccessToken = redirectParams.get('access_token') || '';
+        const redirectAccountId = redirectParams.get('account_id') || '';
+        if (redirectAccessToken && redirectAccountId) {
+          saveState({
+            request_token: '',
+            access_token: redirectAccessToken,
+            account_id: redirectAccountId
+          });
+          redirectParams.delete('access_token');
+          redirectParams.delete('account_id');
+          const cleanSearch = redirectParams.toString();
+          const cleanUrl =
+            window.location.pathname +
+            (cleanSearch ? `?${cleanSearch}` : '') +
+            window.location.hash;
+          window.history.replaceState({}, document.title, cleanUrl);
+
+          setState({
+            status: STATUSES.RESOLVED,
+            error: null,
+            accessToken: redirectAccessToken,
+            accountId: redirectAccountId
+          });
+          return;
+        }
+
         const {
           request_token: requestToken = '',
           access_token: initialAccessToken = '',
@@ -65,7 +94,7 @@ const AuthProvider = ({ children }) => {
         });
       } catch (error) {
         if (error.status === 401)
-          alert('Authentication failed. If you are using Safari, please disable "Prevent cross-site tracking" in your privacy settings. It blocks cross-domain cookies, which this demo site uses storing your state.');
+          alert('Authentication failed. Cross-site login cookies were blocked. Please try again; if it keeps failing, allow third-party cookies for this demo or use a non-private window.');
         
         console.log('[AuthProvider useEffect] error => ', error);
         setState({

--- a/tests/logged-in/search-for-movie-in-add-item-field.spec.ts
+++ b/tests/logged-in/search-for-movie-in-add-item-field.spec.ts
@@ -24,13 +24,14 @@ test.describe('Integration with Search Functionality', { tag: '@agent' }, () => 
     await expect(page.locator('.select-search-container.is-loading')).toBeVisible({ timeout: 1000 });
 
     // 6. Wait for search results to load and verify dropdown appears
-    await expect(page.locator('.movie-option-wrapper button')).toBeVisible({ timeout: 10000 });
-    
+    const searchResults = page.locator('.movie-option-wrapper button');
+    await expect(searchResults.first()).toBeVisible({ timeout: 10000 });
+    await expect(searchResults).not.toHaveCount(0);
+
     // 7. Verify results display with movie titles and relevant info (images and text)
-    const searchResults = page.locator('.movie-option-wrapper button').first();
-    await expect(searchResults).toBeVisible();
-    await expect(searchResults.locator('img')).toBeVisible();
-    await expect(searchResults.locator('span')).toBeVisible();
+    const firstResult = searchResults.first();
+    await expect(firstResult.locator('img')).toBeVisible();
+    await expect(firstResult.locator('span')).toBeVisible();
   });
 
   test('Search for Non-existent Movie Shows No Results Message', async ({ listPage }) => {

--- a/tests/logged-out/api.spec.ts
+++ b/tests/logged-out/api.spec.ts
@@ -92,31 +92,24 @@ test('movie search', async ({ request }) => {
 test('movie credits', async ({ request }) => {
   const response = await request.get(`/3/movie/tt12584954/credits`);
   await expect(response).toBeOK();
-  expect(await response.json()).toEqual(
+  // Fixtures are trimmed for Workers size limits: slim cast fields, no crew.
+  const credits = await response.json();
+  expect(credits).toEqual(
     expect.objectContaining({
+      id: 718821,
       cast: expect.arrayContaining([
         expect.objectContaining({
           name: 'Daisy Edgar-Jones',
-          original_name: 'Daisy Edgar-Jones',
-          known_for_department: 'Acting',
-          popularity: expect.any(Number),
-          profile_path: expect.any(String),
           character: 'Kate',
-        }),
-      ]),
-      crew: expect.arrayContaining([
-        expect.objectContaining({
-          name: 'Ashley Nicole Hudson',
-          original_name: 'Ashley Nicole Hudson',
-          known_for_department: 'Crew',
-          popularity: expect.any(Number),
           profile_path: expect.any(String),
-          department: 'Crew',
-          job: 'Stunts',
+          order: 0,
         }),
       ]),
+      crew: [],
     }),
   );
+  expect(credits.cast.length).toBeGreaterThan(0);
+  expect(credits.cast.length).toBeLessThanOrEqual(15);
 });
 
 test.describe('movie sorting', () => {

--- a/tests/logged-out/movie-list.spec.ts
+++ b/tests/logged-out/movie-list.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test';
 
-test('Avengers: Infinity is the first top rated movie', async ({
+test('The Dark Knight is the first top rated movie', async ({
   page,
 }) => {
   await page.goto('/?category=Top+Rated&page=1');
@@ -9,8 +9,8 @@ test('Avengers: Infinity is the first top rated movie', async ({
   const firstMovieRating = page.getByLabel('rating').first();
 
   await expect(firstMovie).toMatchAriaSnapshot(`
-    - 'link /Avengers: Infinity/':
-      - 'img "poster of Avengers: Infinity War"'
+    - 'link /The Dark Knight/':
+      - 'img "poster of The Dark Knight"'
   `);
   await expect(firstMovieRating).toHaveAccessibleName('rating');
 
@@ -27,8 +27,8 @@ test('Avengers: Infinity is the first top rated movie', async ({
   await test.step('Click on movie and verify details page', async () => {
     await firstMovie.click();
     await expect(page.getByRole('main')).toMatchAriaSnapshot(`
-    - 'heading "Avengers: Infinity War" [level=1]'
-    - heading "Destiny arrives all the same." [level=2]
+    - 'heading "The Dark Knight" [level=1]'
+    - heading "Some men just want to watch the world burn." [level=2]
     - text: /★/
     - paragraph: /\\d+\\.\\d+/
     - heading "The Genres" [level=3]
@@ -36,7 +36,6 @@ test('Avengers: Infinity is the first top rated movie', async ({
     - heading "The Cast" [level=3]
     - link "Website"
     - link "IMDB"
-    - button "Trailer"
     - button "Back"
     `);
   });
@@ -80,6 +79,7 @@ test('dynamic content for first upcoming movie', async ({ page }, testInfo) => {
     await expect(page.getByRole('main')).toMatchAriaSnapshot(`
     - 'heading "${movieName ?? ''}" [level=1]'
     `);
+    // Mock fixtures currently omit trailer videos and spoken languages.
     await expect(page.getByRole('main')).toMatchAriaSnapshot(`
     - 'heading "${movieName ?? ''}" [level=1]'
     - heading [level=2]
@@ -90,7 +90,6 @@ test('dynamic content for first upcoming movie', async ({ page }, testInfo) => {
     - heading "The Cast" [level=3]
     - link "Website"
     - link "IMDB"
-    - button "Trailer"
     - button "Back"
     `);
   });

--- a/tests/logged-out/movie.spec.ts
+++ b/tests/logged-out/movie.spec.ts
@@ -25,14 +25,15 @@ test.describe('Movie Details Page - Content', () => {
 
       await expect(movie.getByLabel('Rating Value')).toHaveText('7.02');
 
+      // spoken_languages / trailer videos are omitted from trimmed mock fixtures
       await expect(movie).toMatchAriaSnapshot(`
         - heading "Twisters" [level=1]
         - heading "Chase. Ride. Survive." [level=2]
         - text: /★/
         - paragraph: "7.02"
-        - text: English / 123 min. / 2024
+        - text: 123 min. / 2024
         - heading "The Genres" [level=3]
-        - list:
+        - list "genres":
           - listitem:
             - link "Action"
           - listitem:
@@ -62,9 +63,10 @@ test.describe('Movie Details Page - Links', () => {
   });
 
   test('links to cast page and back button', async ({ page }) => {
-    await page.getByRole('link', { name: 'Samantha Ireland' }).click();
+    // Cast fixtures were trimmed; use a lead actor that remains in the mock.
+    await page.getByRole('link', { name: 'Daisy Edgar-Jones' }).click();
     await expect(page.getByRole('main').getByRole('heading', { level: 1 }).first())
-      .toHaveText('Samantha Ireland');
+      .toHaveText('Daisy Edgar-Jones');
     await page.getByRole('button', { name: 'Back' }).click();
     await expect(
       page.getByRole('main').getByRole('heading', { level: 1 }).first(),
@@ -77,6 +79,33 @@ test.describe('Movie Details Page - Links', () => {
       tag: '@iframe',
     },
     async ({ page }) => {
+      // Fixtures omit videos; inject a trailer and stub the YouTube embed.
+      await page.route(
+        '*/**/**718821?append_to_response=videos',
+        async (route) => {
+          const response = await route.fetch();
+          const json = await response.json();
+          json.videos = {
+            results: [
+              {
+                key: 'wdov1R5HjXY',
+                name: 'Twisters',
+                site: 'YouTube',
+                type: 'Trailer',
+              },
+            ],
+          };
+          await route.fulfill({ response, json });
+        },
+      );
+      await page.route('https://www.youtube.com/**', async (route) => {
+        await route.fulfill({
+          contentType: 'text/html',
+          body: '<html><body><a href="/watch">Twisters</a></body></html>',
+        });
+      });
+
+      await page.goto('movie?id=718821&page=1');
       await page.getByRole('button', { name: 'Trailer' }).click();
       await expect(page.frameLocator('iframe').getByRole('link', { name: 'Twisters' }))
         .toBeVisible();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Login on the GitHub Pages demo failed after submitting credentials (movies still loaded). This looked like CORS in DevTools, but CORS was already correct — `/4/auth/access_token` returned **401** because browsers blocked cross-site cookies between `debs-obrien.github.io` and the Cloudflare Workers mock API.

## Fix
- After `/auth/access`, redirect back with `access_token` and `account_id` in the **URL hash**.
- AuthProvider reads hash tokens, saves them to `localStorage`, and clears the hash.
- Keep cookies for local/same-site Playwright flows.
- Store approved request tokens in memory as a fallback for the exchange endpoint.

## CI test fixes
Aligned logged-out/logged-in Playwright specs with the trimmed Workers mock fixtures:
- `movie credits` API assertions (slim cast, empty crew)
- add-item search strict-mode locator
- top-rated first movie (`The Dark Knight`)
- movie details aria snapshots (no spoken language / trailer in fixtures)
- cast link uses `Daisy Edgar-Jones`
- trailer test mocks a YouTube trailer into the movie response

## Test plan
- [x] Local: auth, movie credits, add-item search, movie-list, movie details
- [ ] CI green on this PR
- [ ] After merge: Workers + GitHub Pages redeploy
- [ ] Verify login on the live demo (including private/incognito)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fe101-a8a4-7fa8-8ba3-d6ed639fae4b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fe101-a8a4-7fa8-8ba3-d6ed639fae4b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

