### PR TITLE
Point GitHub Pages at the deployed Workers mock URL

### DIFF
--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -34,8 +34,9 @@ jobs:
         env:
           BASEPATH: /playwright-movies-app
           NEXT_PUBLIC_BASEPATH: /playwright-movies-app
+          # Must match the Workers URL from "Deploy mock API" (current account: dobriendev).
           # Override via repo variable NEXT_PUBLIC_TMDB_API_BASE_URL if needed.
-          NEXT_PUBLIC_TMDB_API_BASE_URL: ${{ vars.NEXT_PUBLIC_TMDB_API_BASE_URL != '' && vars.NEXT_PUBLIC_TMDB_API_BASE_URL || 'https://playwright-tmdb-mock.zephyrwmf.workers.dev' }}
+          NEXT_PUBLIC_TMDB_API_BASE_URL: ${{ vars.NEXT_PUBLIC_TMDB_API_BASE_URL != '' && vars.NEXT_PUBLIC_TMDB_API_BASE_URL || 'https://playwright-tmdb-mock.dobriendev.workers.dev' }}
       - name: List build directory (debugging)
         run: ls -la movies-app/out
       - name: Upload artifact

--- a/mock-api/README.md
+++ b/mock-api/README.md
@@ -39,7 +39,7 @@ Get keys at https://www.themoviedb.org/settings/api (free account required).
 
 ## Deploy (Cloudflare Workers)
 
-Current production URL: `https://playwright-tmdb-mock.zephyrwmf.workers.dev`
+Current production URL: `https://playwright-tmdb-mock.dobriendev.workers.dev`
 
 ```bash
 # once (interactive browser login)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Production login still fails with the cross-site cookie alert because the Pages app is built against the **old** mock URL (`playwright-tmdb-mock.zephyrwmf.workers.dev`), while CI now deploys the fixed mock to `playwright-tmdb-mock.dobriendev.workers.dev`.

## Fix
Update the Pages workflow default `NEXT_PUBLIC_TMDB_API_BASE_URL` (and mock-api README) to the dobriendev Workers URL.

## After merge
The **Deploy Next.js site to Pages** workflow should rebuild the site. Then login on https://debs-obrien.github.io/playwright-movies-app/ should work (including private windows).

If a repo variable `NEXT_PUBLIC_TMDB_API_BASE_URL` is still set to the zephyrwmf URL, clear or update it — that variable overrides the workflow default.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fe101-a8a4-7fa8-8ba3-d6ed639fae4b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fe101-a8a4-7fa8-8ba3-d6ed639fae4b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

